### PR TITLE
Decision 2: MacOS hardware for libc++ pre-merge testing

### DIFF
--- a/decisions/decision_002_mac_hardware_for_libcxx.md
+++ b/decisions/decision_002_mac_hardware_for_libcxx.md
@@ -1,0 +1,25 @@
+# Decision 2: MacOS hardware for libc++ pre-merge testing
+
+## Background
+
+Louis Dionne requested MacOS machines for the libc++ pre-merge testing
+[#32](https://github.com/llvm/llvm-iwg/issues/32).
+
+The details for the board are in a [proposal for the
+board](https://docs.google.com/document/d/1gGPIvsUd7hLIRK8Kq3h_otlnpImBgBZlHSONvLWMe1E/).
+That document has limited visibility as it contains pricing information.
+Please request access in case you want to see the details.
+
+*Comment: We need to agree on a way to handle non-public information in the
+working group [#33](https://github.com/llvm/llvm-iwg/issues/33).*
+
+## Decision
+
+1. The infrastructure working group (IWG) supports this request.
+2. The Infrastructure Working Group(IWG) would like to recommend
+   purchasing a twelve (12) month contract MacMiniVault to the board. IWG will
+   work  with the vendor to provide the Foundation Board with all necessary
+   paperwork for fiscal and legal review.  Once the contract is approved and
+   the account is established, IWG will work with the vendor and the libc++ Team
+   to coordinate access to the hardware.  At least one IWG member and one Board
+   member will retain root level access to the leased hardware at all times.


### PR DESCRIPTION
see changed file for the details of the proposal.

I would like to try #38 as a way to decide on this proposal.