### PR TITLE
Fixining the linter version

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -17,7 +17,7 @@ jobs:
 
     # installing more packages as proposed in 
     # https://askubuntu.com/questions/1088662/npm-depends-node-gyp-0-10-9-but-it-is-not-going-to-be-installed
-    - name: install markdownlint-cli@0.31.1
+    - name: install markdownlint-cli@0.32.1
 
       run: |
         sudo apt-get update       

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -17,7 +17,8 @@ jobs:
 
     # installing more packages as proposed in 
     # https://askubuntu.com/questions/1088662/npm-depends-node-gyp-0-10-9-but-it-is-not-going-to-be-installed
-    - name: install markdownlint-cli
+    - name: install markdownlint-cli@0.31.1
+
       run: |
         sudo apt-get update       
         sudo apt-get install -y npm sudo nodejs node-gyp libssl-dev

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
   "MD013": false,
-  "MD034": false
+  "MD034": false,
+  "MD052": false
 }


### PR DESCRIPTION
to avoid getting new rules enforced with version upgrade.

This should fix the build issues we found in #113 and #115 